### PR TITLE
Fixed extra 'thru' text when no dates are selected. Adding wording for area with start or end date when either date is does not have a value

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -57,14 +57,16 @@
 
           <h3 mat-subheader>Current Search</h3>
 
-          <mat-list-item *ngIf="currentDisplayQuery.start_date !== null || currentDisplayQuery.start_date !== '' && currentDisplayQuery.end_date !== null || currentDisplayQuery.end_date !== ''">
+          <mat-list-item *ngIf="(currentDisplayQuery.start_date !== null && currentDisplayQuery.start_date !== '') || (currentDisplayQuery.end_date !== null && currentDisplayQuery.end_date !== '')">
             <h4 mat-line>
               <strong>Date Range</strong>
             </h4>
             <p mat-line>
-              <span>{{currentDisplayQuery.start_date | date:'mediumDate'}}</span>
+              <span *ngIf="currentDisplayQuery.start_date !== null || currentDisplayQuery.start_date !== ''">{{currentDisplayQuery.start_date | date:'mediumDate'}}</span>
+              <span style="color: lightcoral" *ngIf="currentDisplayQuery.start_date == null || currentDisplayQuery.start_date == ''">[no event start date entered]</span>
               <span *ngIf="(currentDisplayQuery.start_date !== null) || (currentDisplayQuery.end_date !== null) || (currentDisplayQuery.start_date !== '') || (currentDisplayQuery.end_date !== '')">&nbsp;thru&nbsp;</span>
-              <span>{{currentDisplayQuery.end_date | date:'mediumDate'}}</span>
+              <span *ngIf="currentDisplayQuery.end_date !== null || currentDisplayQuery.end_date !== ''">{{currentDisplayQuery.end_date | date:'mediumDate'}}</span>
+              <span style="color: lightcoral" *ngIf="currentDisplayQuery.end_date == null || currentDisplayQuery.end_date == ''">[no event end date entered]</span>
             </p>
           </mat-list-item>
 


### PR DESCRIPTION
I made the "[no event end date...]" text a noticeable but not alarming light coral. 