### PR TITLE
Fix TypeScript importing same file with two different casings

### DIFF
--- a/src/app/services/country.service.ts
+++ b/src/app/services/country.service.ts
@@ -7,7 +7,7 @@ import { Observable ,  Subject ,  throwError } from 'rxjs';
 import { APP_SETTINGS } from '@app/app.settings';
 import { APP_UTILITIES } from '@app/app.utilities';
 
-import { Country } from '@interfaces/Country';
+import { Country } from '@interfaces/country';
 
 @Injectable()
 export class CountryService {


### PR DESCRIPTION
_Recreated PR against `dev` branch._

On macOS, when running `npm start` on a fresh clone of master, I was getting the following error:

```
ERROR in src/app/edit-event-location/edit-event-location.component.ts(16,25): error TS1149: File name '/Users/machrist/SGCI/WHISPers/whispers/src/app/interfaces/country.ts' differs from already included file name '/Users/machrist/SGCI/WHISPers/whispers/src/app/interfaces/Country.ts' only in casing.

ℹ ｢wdm｣: Failed to compile.
```

I got the idea from [this StackOverflow answer](https://stackoverflow.com/a/55966939) that TypeScript doesn't like to import the same file using two different cases. Perhaps this code was developed on a case-insensitive filesystem (Windows?) but on my macOS computer I'm getting the above error.

The fix was pretty simple, just changed the one place where country is imported as `@interfaces/Country`.