### PR TITLE
Email verification

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -26,6 +26,7 @@ import { isPlatformBrowser } from '@angular/common';
 import * as $ from 'jquery';
 import * as search_api from 'usgs-search-api';
 import { UserService } from './services/user.service';
+import { ConfirmComponent } from './confirm/confirm.component';
 
 @Component({
   selector: 'app-root',
@@ -253,11 +254,31 @@ export class AppComponent implements OnInit {
     this.userService.confirmEmail(userId, emailToken)
       .subscribe(
         (user) => {
-          this.openAuthenticationDialog({userEmailVerified: true});
+          // Route to /home/ to remove the verification query parameters
+          return this.router.navigate(['/home/'])
+          .then(() => {
+            this.openAuthenticationDialog({userEmailVerified: true});
+          })
         },
         error => {
-          // TODO: notify user of email confirmation error
-          this.errorMessage = <any>error;
+          let errorMessage = error;
+          try {
+            errorMessage = JSON.parse(error).status;
+          } catch (error) {
+            // Ignore JSON parsing error
+          }
+          const confirmDialogRef = this.dialog.open(ConfirmComponent,
+            {
+              disableClose: true,
+              data: {
+                title: 'Email Verification Failed',
+                titleIcon: 'warning',
+                message: 'Failed to verify your email address: ' + errorMessage,
+                confirmButtonText: 'OK',
+                showCancelButton: false
+              }
+            }
+          );
         }
       );
   }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -25,8 +25,8 @@ import { isPlatformBrowser } from '@angular/common';
 
 import * as $ from 'jquery';
 import * as search_api from 'usgs-search-api';
-import { UserService } from './services/user.service';
-import { ConfirmComponent } from './confirm/confirm.component';
+import { UserService } from '@services/user.service';
+import { ConfirmComponent } from '@confirm/confirm.component';
 
 @Component({
   selector: 'app-root',
@@ -102,9 +102,8 @@ export class AppComponent implements OnInit {
     // }
 
     this.route.queryParams.subscribe(params => {
-      // TODO: make constants
-      const userId = params['user-id'];
-      const emailToken = params['email-token'];
+      const userId = params[APP_SETTINGS.EMAIL_VERIFICATION_USER_ID_QUERY_PARAM];
+      const emailToken = params[APP_SETTINGS.EMAIL_VERIFICATION_EMAIL_TOKEN_QUERY_PARAM];
 
       if (userId && emailToken) {
         this.confirmEmailAddress(userId, emailToken);

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -200,7 +200,7 @@ export class AppComponent implements OnInit {
     this.authenticationService.logout();
   }
 
-  openAuthenticationDialog(data) {
+  openAuthenticationDialog(data = null) {
     this.authenticationDialogRef = this.dialog.open(AuthenticationComponent, {
       // minWidth: '60%'
       // disableClose: true, data: {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -25,6 +25,7 @@ import { isPlatformBrowser } from '@angular/common';
 
 import * as $ from 'jquery';
 import * as search_api from 'usgs-search-api';
+import { UserService } from './services/user.service';
 
 @Component({
   selector: 'app-root',
@@ -60,7 +61,8 @@ export class AppComponent implements OnInit {
     public currentUserService: CurrentUserService,
     private authenticationService: AuthenticationService,
     private notificationService: NotificationService,
-    private resultsCountService: ResultsCountService
+    private resultsCountService: ResultsCountService,
+    private userService: UserService,
   ) {
 
     currentUserService.currentUser.subscribe(user => {
@@ -94,6 +96,16 @@ export class AppComponent implements OnInit {
     //     'username': ''
     //   });
     // }
+
+    this.route.queryParams.subscribe(params => {
+      // TODO: make constants
+      const userId = params['user-id'];
+      const emailToken = params['email-token'];
+
+      if (userId && emailToken) {
+        this.confirmEmailAddress(userId, emailToken);
+      }
+    })
 
     if (sessionStorage.getItem('currentUser')) {
       const currentUserObj = JSON.parse(sessionStorage.getItem('currentUser'));
@@ -188,13 +200,14 @@ export class AppComponent implements OnInit {
     this.authenticationService.logout();
   }
 
-  openAuthenticationDialog() {
+  openAuthenticationDialog(data) {
     this.authenticationDialogRef = this.dialog.open(AuthenticationComponent, {
       // minWidth: '60%'
       // disableClose: true, data: {
       //   query: this.currentDisplayQuery
       // }
       // height: '75%'
+      data: data
     });
   }
 
@@ -233,5 +246,19 @@ export class AppComponent implements OnInit {
         window.clearInterval(scrollToTop);
       }
     }, 16);
+  }
+
+  confirmEmailAddress(userId:String, emailToken:String) {
+
+    this.userService.confirmEmail(userId, emailToken)
+      .subscribe(
+        (user) => {
+          this.openAuthenticationDialog({userEmailVerified: true});
+        },
+        error => {
+          // TODO: notify user of email confirmation error
+          this.errorMessage = <any>error;
+        }
+      );
   }
 }

--- a/src/app/app.settings.ts
+++ b/src/app/app.settings.ts
@@ -171,6 +171,9 @@ export class APP_SETTINGS {
 
     public static get GO_USA_GOV_JSON_HEADERS() { return new Headers({}); }
 
+    public static get EMAIL_VERIFICATION_USER_ID_QUERY_PARAM() { return "user-id"; }
+    public static get EMAIL_VERIFICATION_EMAIL_TOKEN_QUERY_PARAM() { return "email-token"; }
+
     public static get AUTH_HEADERS() {
         return new Headers({
             'Authorization': 'Basic ' + btoa(sessionStorage.username + ':' + sessionStorage.password)

--- a/src/app/authentication/authentication.component.html
+++ b/src/app/authentication/authentication.component.html
@@ -6,6 +6,10 @@
   <form [formGroup]="loginForm" id="loginForm">
 
     <div class="vertical-form-container">
+      <p *ngIf="data && data.userEmailVerified">
+        <mat-icon color="accent">check</mat-icon>
+        Your email address was successfully verified! You can login now.
+      </p>
 
       <mat-form-field class="form-control">
         <input matInput placeholder="Username" formControlName="username">
@@ -18,7 +22,7 @@
         <mat-error *ngIf="loginForm.get('password').invalid">{{getErrorMessage('password')}}</mat-error>
       </mat-form-field>
 	</div>
-	
+
   </form>
 
   <div class="forgot-password-div">

--- a/src/app/authentication/authentication.component.ts
+++ b/src/app/authentication/authentication.component.ts
@@ -15,6 +15,7 @@ import { MatSnackBar } from '@angular/material';
 import { MAT_DIALOG_DATA } from '@angular/material';
 
 import { User } from '@interfaces/user';
+import { ConfirmComponent } from '@app/confirm/confirm.component';
 
 
 @Component({
@@ -32,6 +33,8 @@ export class AuthenticationComponent implements OnInit {
 
   submitLoading = false;
 
+  invalidPassword = false;
+
   constructor(
     formBuilder: FormBuilder,
     public authenticationService: AuthenticationService,
@@ -40,6 +43,7 @@ export class AuthenticationComponent implements OnInit {
     public router: Router,
     private route: ActivatedRoute,
     public snackBar: MatSnackBar,
+    private dialog: MatDialog,
     @Inject(MAT_DIALOG_DATA) public data: any
   ) {
     this.loginForm = formBuilder.group({
@@ -86,7 +90,21 @@ export class AuthenticationComponent implements OnInit {
           this.submitLoading = false;
           this.authenticationErrorFlag = true;
           if (error.status === 403) {
-            this.openSnackBar('Invalid username and/or password. Please try again.', 'OK', 8000);
+            const errorData = error.json();
+            if (errorData.type === 'unverified_email') {
+              this.dialog.open(ConfirmComponent, {
+                data: {
+                  title: "User Email Not Verified",
+                  titleIcon: "warning",
+                  message:
+                    "Please verify your email address by clicking the link in the email we sent. Once your email is verified you will be able to log in.",
+                  confirmButtonText: "OK",
+                  showCancelButton: false,
+                },
+              });
+            } else {
+              this.openSnackBar('Invalid username and/or password. Please try again.', 'OK', 8000);
+            }
           } else {
             this.openSnackBar('Error. Failed to login. Error message: ' + error, 'OK', 8000);
           }

--- a/src/app/authentication/authentication.component.ts
+++ b/src/app/authentication/authentication.component.ts
@@ -39,7 +39,8 @@ export class AuthenticationComponent implements OnInit {
     public currentUserService: CurrentUserService,
     public router: Router,
     private route: ActivatedRoute,
-    public snackBar: MatSnackBar
+    public snackBar: MatSnackBar,
+    @Inject(MAT_DIALOG_DATA) public data: any
   ) {
     this.loginForm = formBuilder.group({
       username: ['', Validators.required],

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -78,6 +78,17 @@ export class UserService {
       catchError(this.handleError),);
   }
 
+  public confirmEmail(userId, emailToken): Observable<User> {
+
+    const options = new RequestOptions({
+      headers: APP_SETTINGS.MIN_JSON_HEADERS
+    });
+
+    return this._http.get(APP_SETTINGS.USERS_URL + userId + '/confirm_email/?token=' + encodeURIComponent(emailToken), options).pipe(
+      map((response: Response) => <any>response.json()),
+      catchError(this.handleError),);
+  }
+
   private handleError(error: Response) {
     console.error(error);
     return throwError(JSON.stringify(error.json()) || 'Server error');

--- a/src/app/user-registration/user-registration.component.html
+++ b/src/app/user-registration/user-registration.component.html
@@ -4,22 +4,6 @@
   Professionals' : ''}}
 </h1>
 <mat-dialog-content>
-
-  <mat-card *ngIf="userRegistrationSuccessful; else formBlock">
-    <mat-card-header>
-      <mat-card-title>User Registration Request Successful</mat-card-title>
-    </mat-card-header>
-    <mat-card-content>
-      <p>
-        Thank you for registering. We've sent an email to
-        <b>{{userRegistrationForm.get('email').value}}</b>. Please click the
-        link in that email to confirm your email address and complete the
-        registration process. If you don't see the email in your inbox,
-        please also check your "Junk" or "Spam" folder.
-      </p>
-    </mat-card-content>
-  </mat-card>
-  <ng-template #formBlock>
   <form [formGroup]="userRegistrationForm" class="registration-form" autocomplete="off">
 
     <div class="vertical-form-container">
@@ -203,24 +187,17 @@
 
 
   </form>
-  </ng-template>
 </mat-dialog-content>
 
 <mat-dialog-actions>
   <div class="detail-section-buttons">
-
-    <button *ngIf="userRegistrationSuccessful; else buttonsBlock" mat-button color="primary" mat-dialog-close>
-      OK
+    <button mat-button color="warn" (click)="this.userRegistrationDialogRef.close('cancel');">
+      <mat-icon>cancel</mat-icon>&nbsp;Cancel
     </button>
-    <ng-template #buttonsBlock>
-      <button mat-button color="warn" (click)="this.userRegistrationDialogRef.close('cancel');">
-        <mat-icon>cancel</mat-icon>&nbsp;Cancel
-      </button>
-      <button mat-button color="primary" type="submit" [disabled]="userRegistrationForm.invalid"
-        (click)="onSubmit(userRegistrationForm.value)">
-        <mat-icon>{{data.actionButtonIcon}}</mat-icon>{{data.action_button_text}}
-      </button>
-      <mat-progress-bar mode="indeterminate" *ngIf="submitLoading"></mat-progress-bar>
-    </ng-template>
+    <button mat-button color="primary" type="submit" [disabled]="userRegistrationForm.invalid"
+      (click)="onSubmit(userRegistrationForm.value)">
+      <mat-icon>{{data.actionButtonIcon}}</mat-icon>{{data.action_button_text}}
+    </button>
+    <mat-progress-bar mode="indeterminate" *ngIf="submitLoading"></mat-progress-bar>
   </div>
 </mat-dialog-actions>

--- a/src/app/user-registration/user-registration.component.html
+++ b/src/app/user-registration/user-registration.component.html
@@ -4,6 +4,22 @@
   Professionals' : ''}}
 </h1>
 <mat-dialog-content>
+
+  <mat-card *ngIf="userRegistrationSuccessful; else formBlock">
+    <mat-card-header>
+      <mat-card-title>User Registration Request Successful</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <p>
+        Thank you for registering. We've sent an email to
+        <b>{{userRegistrationForm.get('email').value}}</b>. Please click the
+        link in that email to confirm your email address and complete the
+        registration process. If you don't see the email in your inbox,
+        please also check your "Junk" or "Spam" folder.
+      </p>
+    </mat-card-content>
+  </mat-card>
+  <ng-template #formBlock>
   <form [formGroup]="userRegistrationForm" class="registration-form" autocomplete="off">
 
     <div class="vertical-form-container">
@@ -24,7 +40,7 @@
 
         <!-- Last Name -->
         <mat-form-field class="form-control">
-          <input matInput placeholder="Last Name" formControlName="last_name">          
+          <input matInput placeholder="Last Name" formControlName="last_name">
           <mat-hint align="start">{{regLastNameTooltip()}}</mat-hint>
         </mat-form-field>
 
@@ -35,7 +51,7 @@
         <!-- Email address -->
         <mat-form-field class="form-control">
           <input matInput placeholder="Email Address" formControlName="email" required>
-          <mat-icon class="hint-hover-text" matSuffix 
+          <mat-icon class="hint-hover-text" matSuffix
                 matTooltip={{regemailAddressTooltip()}} matTooltipClass="tooltip-breakline">
           help</mat-icon>
           <mat-error *ngIf="userRegistrationForm.get('email').invalid">{{getErrorMessage('email')}}</mat-error>
@@ -55,7 +71,7 @@
         <!-- Password -->
         <mat-form-field class="form-control">
           <input matInput type="password" placeholder="Password" formControlName="password" required>
-          <mat-icon class="hint-hover-text" matSuffix 
+          <mat-icon class="hint-hover-text" matSuffix
                 matTooltip={{regPasswordTooltip()}} matTooltipClass="tooltip-breakline">
           help</mat-icon>
         </mat-form-field>
@@ -101,7 +117,7 @@
             {{organization.name}}
           </mat-option>
         </mat-select>
-        <mat-icon class="hint-hover-text" matSuffix 
+        <mat-icon class="hint-hover-text" matSuffix
                   matTooltip={{regOrganizationTooltip()}} matTooltipClass="tooltip-breakline">
             help</mat-icon>
       </mat-form-field>
@@ -115,7 +131,7 @@
           <mat-option [value]="4">Partner Manager</mat-option>
           <mat-option [value]="3">Partner Administrator</mat-option>
         </mat-select>
-        <mat-icon class="hint-hover-text" matSuffix 
+        <mat-icon class="hint-hover-text" matSuffix
                   matTooltip={{regRoleTooltip()}} matTooltipClass="tooltip-breakline">
             help</mat-icon>
       </mat-form-field>
@@ -126,12 +142,12 @@
       <mat-form-field class="general-comment-text-area">
         <textarea matInput #requestComment maxlength="1000" minRows="3" placeholder="Comment"
           formControlName="comment"></textarea>
-          <mat-icon class="hint-hover-text" matSuffix 
+          <mat-icon class="hint-hover-text" matSuffix
                   matTooltip={{regCommentTooltip()}} matTooltipClass="tooltip-breakline">
             help</mat-icon>
         <mat-hint align="end">{{requestComment.value.length}} / 1000</mat-hint>
       </mat-form-field>
-  
+
         <div>
           <h3>Disclaimer</h3>
           <p class="text-smaller">The data on this website are provided for situational awareness of wildlife health
@@ -146,7 +162,7 @@
 
         <div *ngIf="data.registration_type === 'partner'" class="disclaimers">
             <div>
-              <h3>Terms of Use<mat-icon class="hint-hover-text" matSuffix 
+              <h3>Terms of Use<mat-icon class="hint-hover-text" matSuffix
                       matTooltip={{regTermsOfUseTooltip()}} matTooltipClass="tooltip-breakline">
                 help</mat-icon></h3>
               <p class="text-smaller">The USGS National Wildlife Health Center (NWHC) conducts wildlife disease
@@ -154,7 +170,7 @@
                 provides a collaborative web-based interface for data entry and communication about wildlife health events.
                 By using this site to request diagnostic assistance from NWHC, the user acknowledges that they maintain
                 appropriate federal or state authority for collection and shipment of wildlife specimens
-    
+
                 <p class="text-smaller">By default, basic summary information such as county location, species affected, and
                   diagnosis will be made
                   publicly available. We recognize the sensitive nature of aspects of these investigations, including but
@@ -163,13 +179,13 @@
                   registered natural resource management professionals entering data to WHISPers can choose to limit the
                   visibility of sensitive data. In order to maintain the integrity of the database and information served
                   through it, a limited number of staff at NWHC will be able to see all data entered.
-    
+
             </div>
-    
+
             <mat-checkbox formControlName="terms" appearance="outline">I agree to the terms of use</mat-checkbox>
-    
+
           </div>
-  
+
       </div>
 
       <mat-divider></mat-divider>
@@ -187,17 +203,24 @@
 
 
   </form>
+  </ng-template>
 </mat-dialog-content>
 
 <mat-dialog-actions>
   <div class="detail-section-buttons">
-    <button mat-button color="warn" (click)="this.userRegistrationDialogRef.close('cancel');">
-      <mat-icon>cancel</mat-icon>&nbsp;Cancel
+
+    <button *ngIf="userRegistrationSuccessful; else buttonsBlock" mat-button color="primary" mat-dialog-close>
+      OK
     </button>
-    <button mat-button color="primary" type="submit" [disabled]="userRegistrationForm.invalid"
-      (click)="onSubmit(userRegistrationForm.value)">
-      <mat-icon>{{data.actionButtonIcon}}</mat-icon>{{data.action_button_text}}
-    </button>
-    <mat-progress-bar mode="indeterminate" *ngIf="submitLoading"></mat-progress-bar>
+    <ng-template #buttonsBlock>
+      <button mat-button color="warn" (click)="this.userRegistrationDialogRef.close('cancel');">
+        <mat-icon>cancel</mat-icon>&nbsp;Cancel
+      </button>
+      <button mat-button color="primary" type="submit" [disabled]="userRegistrationForm.invalid"
+        (click)="onSubmit(userRegistrationForm.value)">
+        <mat-icon>{{data.actionButtonIcon}}</mat-icon>{{data.action_button_text}}
+      </button>
+      <mat-progress-bar mode="indeterminate" *ngIf="submitLoading"></mat-progress-bar>
+    </ng-template>
   </div>
 </mat-dialog-actions>

--- a/src/app/user-registration/user-registration.component.ts
+++ b/src/app/user-registration/user-registration.component.ts
@@ -21,6 +21,7 @@ import { Role } from '@interfaces/role';
 
 import { APP_SETTINGS } from '@app/app.settings';
 import { FIELD_HELP_TEXT } from '@app/app.field-help-text';
+import { ConfirmComponent } from '@app/confirm/confirm.component';
 declare let gtag: Function;
 
 @Component({
@@ -32,7 +33,6 @@ export class UserRegistrationComponent implements OnInit {
 
   errorMessage = '';
   submitLoading = false;
-  userRegistrationSuccessful = false;
 
   currentUser;
 
@@ -109,6 +109,7 @@ export class UserRegistrationComponent implements OnInit {
     private organizationService: OrganizationService,
     private roleService: RoleService,
     private userService: UserService,
+    private dialog: MatDialog,
     @Inject(MAT_DIALOG_DATA) public data: any
   ) {
 
@@ -230,7 +231,21 @@ export class UserRegistrationComponent implements OnInit {
       .subscribe(
         (event) => {
           this.submitLoading = false;
-          this.userRegistrationSuccessful = true;
+          this.userRegistrationDialogRef.close();
+          this.dialog.open(ConfirmComponent, {
+            data: {
+              title: "User Registration Request Successful",
+              titleIcon: "check",
+              message:
+              `Thank you for registering. We've sent an email to
+              ${this.userRegistrationForm.get('email').value}. Please click the
+              link in that email to confirm your email address and complete the
+              registration process. If you don't see the email in your inbox,
+              please also check your "Junk" or "Spam" folder.`,
+              confirmButtonText: "OK",
+              showCancelButton: false,
+            },
+          });
           // this.currentUserService.updateCurrentUser(event);
           // sessionStorage.first_name = event.first_name;
           // sessionStorage.last_name = event.last_name;

--- a/src/app/user-registration/user-registration.component.ts
+++ b/src/app/user-registration/user-registration.component.ts
@@ -32,6 +32,7 @@ export class UserRegistrationComponent implements OnInit {
 
   errorMessage = '';
   submitLoading = false;
+  userRegistrationSuccessful = false;
 
   currentUser;
 
@@ -229,8 +230,7 @@ export class UserRegistrationComponent implements OnInit {
       .subscribe(
         (event) => {
           this.submitLoading = false;
-          this.openSnackBar('User Registration Successful', 'OK', 5000);
-          this.userRegistrationDialogRef.close();
+          this.userRegistrationSuccessful = true;
           // this.currentUserService.updateCurrentUser(event);
           // sessionStorage.first_name = event.first_name;
           // sessionStorage.last_name = event.last_name;


### PR DESCRIPTION
Introduce an email verification step into the user registration process.

- when a user requests an account, a dialog informs the user to check their inbox for an email with a link that when clicked will verify their email address
- handle the email verification link by grabbing the token and relaying to the REST API. Inform the user on success or failure.
- handle situation where user tries to login but hasn't verified their email yet

These frontend changes depend on backend changes. See issue https://github.com/USGS-WiM/whispersservices_django/issues/386. I'll update this PR once I've created the backend PR.
