### PR TITLE
Add reCAPTCHA API key for prod and test envs

### DIFF
--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -4,6 +4,6 @@ export const environment = {
   version: require('../../package.json').version,
   ////////////// PROD /////////////////
   // API root for prod
-  recaptcha_site_key: '',
+  recaptcha_site_key: '6Lc43c4ZAAAAAO3zFzGMumcVHiPN6vChVPvJqc9N',
   api_root: 'https://whispers.usgs.gov/api/',
 };

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -8,6 +8,6 @@ export const environment = {
   // banner color for test
   // banner_text_color: '#FFFF00'
   // API root for test
-  recaptcha_site_key: '',
+  recaptcha_site_key: '6Lc43c4ZAAAAAO3zFzGMumcVHiPN6vChVPvJqc9N',
   api_root: 'https://whisperstest.wim.usgs.gov/api/',
 };


### PR DESCRIPTION
Google reCAPTCHA requires an API key pair, one on the frontend and one on the backend. I previously added the frontend API key into the environment.ts file, for local development, but it is need in the prod and test environments too.
